### PR TITLE
Refactored Fetch Calls into `UseBackend` Hook

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ frontend/.env.production.local
 frontend/npm-debug.log*
 frontend/yarn-debug.log*
 frontend/yarn-error.log*
+bun.lockb

--- a/frontend/src/functions/UseBackend.jsx
+++ b/frontend/src/functions/UseBackend.jsx
@@ -1,0 +1,36 @@
+const backend = "http://localhost:8000";
+const frontend = "http://localhost:3000";
+
+export default async function UseBackend(type, endpoint, body) {
+  if (!type || !endpoint) {
+    return null;
+  }
+  const res = await fetch(backend + "/" + endpoint, {
+    method: type,
+    credentials: "include",
+    headers:
+      body instanceof FormData
+        ? {
+            "Access-Control-Allow-Credentials": true,
+            "Access-Control-Allow-Origin": frontend,
+          }
+        : {
+            "Content-Type": "application/json",
+            "Access-Control-Allow-Credentials": true,
+            "Access-Control-Allow-Origin": frontend,
+          },
+    body:
+      type === "POST"
+        ? body instanceof FormData
+          ? body
+          : JSON.stringify(body)
+        : undefined,
+  });
+  if (!res.ok) {
+    const errorText = await res.json();
+    console.log(errorText);
+    return null;
+  }
+  const json = await res.json();
+  return json;
+}


### PR DESCRIPTION
### Refactored Fetch Calls into `UseBackend` Hook

#### Description

To avoid repetitive boilerplate code for `fetch` requests in the frontend, I've refactored the existing `fetch` logic into a reusable `UseBackend` hook.

---

#### Example of Existing `fetch` Call

Previously, each request was manually defined like this:

```javascript
fetch('http://localhost:8000/truth', {
  method: 'POST',
  credentials: 'include',
  headers: {
    'Content-Type': 'application/json',
  },
  body: JSON.stringify({
    user_id: currentUser.id,
    content: newTruth,
    category
  }),
})
  .then(response => response.json())
  .then(data => {
    setTruths([data, ...truths]);
    setNewTruth('');
  })
  .catch(error => console.error('Error:', error));
```

This required repeating the entire setup for each new request, which was inefficient.

My UseBackend Hook

```
try {
  var data = await UseBackend("POST", "truth", {
    user_id: currentUser.id,
    content: newTruth,
    category,
  });
  setTruths([data, ...truths]);
  setNewTruth("");
} catch (error) {
  console.log(error);
}
```